### PR TITLE
Add tenant support to monitor fetch

### DIFF
--- a/public/monitor/js/monitor.js
+++ b/public/monitor/js/monitor.js
@@ -1,10 +1,15 @@
-
 // public/monitor/js/monitor.js
+
+// Captura o tenantId da URL
+const urlParams = new URL(location).searchParams;
+const tenantId  = urlParams.get('t');
+
 async function fetchCurrent() {
   try {
-    const res = await fetch('/.netlify/functions/status');
+    const res = await fetch(`/.netlify/functions/status?t=${tenantId}`);
     const { currentCall } = await res.json();
-    document.getElementById('current').textContent = currentCall;
+    document.getElementById('current').textContent =
+      currentCall > 0 ? currentCall : '–';
   } catch (e) {
     console.error('Erro ao buscar currentCall:', e);
   }


### PR DESCRIPTION
## Summary
- read tenantId from query string in monitor.js
- append `?t=<tenant>` when querying status endpoint
- show dash when there is no current ticket

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6842373ee8c88329bc2b86b8b5dffe64