### PR TITLE
Update queue cancel flow

### DIFF
--- a/functions/cancelar.js
+++ b/functions/cancelar.js
@@ -15,6 +15,11 @@ export async function handler(event) {
   const ticketNum = await redis.get(prefix + `ticket:${clientId}`);
   await redis.del(prefix + `ticket:${clientId}`);
 
+  // Se havia ticket, marca-o como cancelado
+  if (ticketNum) {
+    await redis.sadd(prefix + "cancelledSet", ticketNum);
+  }
+
   // Log de cancelamento
   const ts = Date.now();
   await redis.lpush(

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -89,7 +89,7 @@
 
     <!-- Histórico de Cancelados -->
     <section class="history-panel">
-      <h2>Cancelados</h2>
+      <h2>Cancelados (<span id="cancel-count">0</span>)</h2>
       <ul id="cancel-list" class="list"></ul>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- mark cancelled tickets in Redis
- skip cancelled tickets when calling next
- expose cancelled tickets and count
- show cancellation count and filter manual options on monitor

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68423bacf2988329b9650b9f1830256b