### PR TITLE
Add web push notifications

### DIFF
--- a/functions/saveSubscription.js
+++ b/functions/saveSubscription.js
@@ -1,0 +1,31 @@
+import { Redis } from "@upstash/redis";
+
+export async function handler(event) {
+  if (event.httpMethod !== "POST") {
+    return { statusCode: 405, body: "Method Not Allowed" };
+  }
+  const url = new URL(event.rawUrl);
+  const tenantId = url.searchParams.get("t");
+  if (!tenantId) {
+    return { statusCode: 400, body: "Missing tenantId" };
+  }
+  let data;
+  try {
+    data = JSON.parse(event.body || "{}");
+  } catch {
+    return { statusCode: 400, body: "Invalid JSON" };
+  }
+  const { clientId, subscription } = data;
+  if (!clientId || !subscription) {
+    return { statusCode: 400, body: "Missing data" };
+  }
+
+  const redis = Redis.fromEnv();
+  const prefix = `tenant:${tenantId}:`;
+  await redis.set(prefix + `subscription:${clientId}`, JSON.stringify(subscription));
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({ saved: true })
+  };
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "@upstash/redis": "^1.20.0",
     "uuid": "^9.0.0",
     "bcryptjs": "^2.4.3",
-    "faunadb": "^4.6.0"
+    "faunadb": "^4.6.0",
+    "web-push": "^3.4.4"
   },
   "engines": {
     "node": ">=16"

--- a/public/client/sw.js
+++ b/public/client/sw.js
@@ -1,0 +1,9 @@
+self.addEventListener('push', event => {
+  const data = event.data ? event.data.json() : {};
+  const title = data.title || 'Sua vez!';
+  const options = {
+    body: data.body || 'Dirija-se ao atendimento.',
+    icon: '/img/icon-sannext.png'
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});


### PR DESCRIPTION
## Summary
- register service worker and subscribe for push notifications on the client
- add client service worker with push handler
- store push subscriptions in Redis
- send push message when ticket is called
- include `web-push` dependency

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845f7ea6fe08329ade2bcfa4c28f981