### PR TITLE
Add audio alerts and responsive monitor

### DIFF
--- a/public/monitor/css/monitor.css
+++ b/public/monitor/css/monitor.css
@@ -32,6 +32,27 @@ h1 {
   animation: blink 1s linear infinite;
 }
 
+.alert-toggle {
+  margin-top: 1rem;
+  font-size: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+@media (max-width: 600px) {
+  h1 {
+    font-size: 1.5rem;
+  }
+  .number {
+    font-size: 4rem;
+  }
+  .name {
+    font-size: 1.5rem;
+  }
+}
+
 @keyframes blink {
   0%,50%,100% { opacity:1; }
   25%,75% { opacity:0; }

--- a/public/monitor/index.html
+++ b/public/monitor/index.html
@@ -11,6 +11,11 @@
     <h1>Chamando</h1>
     <div id="current" class="number">—</div>
     <div id="current-name" class="name"></div>
+    <label class="alert-toggle">
+      <input type="checkbox" id="enable-alerts" />
+      Alertar chamadas
+    </label>
+    <audio id="alert-sound" preload="auto" src="https://actions.google.com/sounds/v1/alarms/alarm_clock.ogg"></audio>
   </div>
   <script src="js/monitor.js"></script>
 </body>

--- a/public/monitor/js/monitor.js
+++ b/public/monitor/js/monitor.js
@@ -1,5 +1,15 @@
 
 // public/monitor/js/monitor.js
+const alertSound   = document.getElementById('alert-sound');
+const enableAlerts = document.getElementById('enable-alerts');
+let lastCall;
+
+// restaura preferencia
+enableAlerts.checked = localStorage.getItem('monitorAlerts') === 'on';
+enableAlerts.addEventListener('change', () => {
+  localStorage.setItem('monitorAlerts', enableAlerts.checked ? 'on' : 'off');
+});
+
 async function fetchCurrent() {
   try {
     const res = await fetch('/.netlify/functions/status');
@@ -15,6 +25,17 @@ async function fetchCurrent() {
       currentEl.classList.remove('manual');
       nameEl.textContent = '';
     }
+
+    if (lastCall !== undefined && currentCall !== lastCall && enableAlerts.checked) {
+      alertSound.currentTime = 0;
+      alertSound.play().catch(() => {});
+      if ('speechSynthesis' in window) {
+        const utter = new SpeechSynthesisUtterance(`É a sua vez: ${currentCall} ${name || ''}`);
+        utter.lang = 'pt-BR';
+        speechSynthesis.speak(utter);
+      }
+    }
+    lastCall = currentCall;
   } catch (e) {
     console.error('Erro ao buscar currentCall:', e);
   }


### PR DESCRIPTION
## Summary
- add checkbox and audio to monitor
- implement alert logic with speech synthesis
- tweak monitor styles and responsiveness

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68544b4ee4e08329901cd69d18b2a475