### PR TITLE
Hide report button until tickets exist

### DIFF
--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -93,6 +93,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const reportSummary  = document.getElementById('report-summary');
   const reportChartEl  = document.getElementById('report-chart');
 
+  // Botão de relatório oculto até haver dados
+  btnReport.hidden = true;
+
   // QR Interaction setup
   const qrContainer    = document.getElementById('qrcode');
   const qrOverlay      = document.createElement('div');
@@ -250,6 +253,9 @@ function startBouncingCompanyName(text) {
         div.textContent = n;
         attendedThumbsEl.appendChild(div);
       });
+
+      // Exibe o botão de relatório apenas se houver tickets registrados
+      btnReport.hidden = ticketCounter === 0;
 
       updateManualOptions();
     } catch (e) {


### PR DESCRIPTION
## Summary
- hide the report button by default
- show report button only when there are tickets

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68548345335883298436564788f7d8ac