### PR TITLE
Add Ably real‑time integration

### DIFF
--- a/functions/ablyClient.js
+++ b/functions/ablyClient.js
@@ -1,0 +1,12 @@
+import Ably from 'ably/promises';
+
+const ably = new Ably.Rest(process.env.ABLY_API_KEY);
+
+export function publish(tenantId, event, data) {
+  try {
+    const channel = ably.channels.get(`tenant:${tenantId}`);
+    return channel.publish(event, data);
+  } catch (err) {
+    console.error('Ably publish error:', err);
+  }
+}

--- a/functions/ablyToken.js
+++ b/functions/ablyToken.js
@@ -1,0 +1,20 @@
+import Ably from 'ably/promises';
+
+export async function handler(event) {
+  const url = new URL(event.rawUrl);
+  const tenantId = url.searchParams.get('t');
+  if (!tenantId) {
+    return { statusCode: 400, body: 'Missing tenantId' };
+  }
+
+  const ably = new Ably.Rest(process.env.ABLY_API_KEY);
+  try {
+    const tokenRequest = await ably.auth.createTokenRequest({
+      capability: JSON.stringify({ [`tenant:${tenantId}`]: ['subscribe'] })
+    });
+    return { statusCode: 200, body: JSON.stringify(tokenRequest) };
+  } catch (err) {
+    console.error('Ably token error:', err);
+    return { statusCode: 500, body: JSON.stringify({ error: 'Ably error' }) };
+  }
+}

--- a/functions/atendido.js
+++ b/functions/atendido.js
@@ -1,4 +1,5 @@
 import { Redis } from "@upstash/redis";
+import { publish } from "./ablyClient.js";
 
 const LOG_TTL = 60 * 60 * 24 * 30; // 30 days
 
@@ -58,6 +59,8 @@ export async function handler(event) {
   );
   await redis.ltrim(prefix + "log:attended", 0, 999);
   await redis.expire(prefix + "log:attended", LOG_TTL);
+
+  await publish(tenantId, "attended", { ticket: Number(ticket), ts, duration, wait });
 
   return {
     statusCode: 200,

--- a/functions/cancelar.js
+++ b/functions/cancelar.js
@@ -1,4 +1,5 @@
 import { Redis } from "@upstash/redis";
+import { publish } from "./ablyClient.js";
 
 const LOG_TTL = 60 * 60 * 24 * 30; // 30 days
 
@@ -47,6 +48,8 @@ export async function handler(event) {
     );
     await redis.ltrim(prefix + "log:cancelled", 0, 999);
     await redis.expire(prefix + "log:cancelled", LOG_TTL);
+
+    await publish(tenantId, "cancelled", { ticket: Number(ticketNum), ts, reason, duration: duration ? Number(duration) : 0, wait });
 
     return {
       statusCode: 200,

--- a/functions/chamar.js
+++ b/functions/chamar.js
@@ -1,4 +1,5 @@
 import { Redis } from "@upstash/redis";
+import { publish } from "./ablyClient.js";
 
 const LOG_TTL = 60 * 60 * 24 * 30; // 30 days
 
@@ -93,6 +94,8 @@ export async function handler(event) {
   );
   await redis.ltrim(prefix + "log:called", 0, 999);
   await redis.expire(prefix + "log:called", LOG_TTL);
+
+  await publish(tenantId, "called", { ticket: next, attendant, ts, wait, name });
 
   return {
     statusCode: 200,

--- a/functions/entrar.js
+++ b/functions/entrar.js
@@ -1,5 +1,6 @@
 import { Redis } from "@upstash/redis";
 import { v4 as uuidv4 } from "uuid";
+import { publish } from "./ablyClient.js";
 
 const LOG_TTL = 60 * 60 * 24 * 30; // 30 days
 
@@ -27,6 +28,9 @@ export async function handler(event) {
   await redis.lpush(prefix + "log:entered", JSON.stringify({ ticket: ticketNumber, ts }));
   await redis.ltrim(prefix + "log:entered", 0, 999);
   await redis.expire(prefix + "log:entered", LOG_TTL);
+
+  // Notifica via Ably
+  await publish(tenantId, "entered", { ticket: ticketNumber, ts });
 
   return {
     statusCode: 200,

--- a/functions/manualTicket.js
+++ b/functions/manualTicket.js
@@ -1,4 +1,5 @@
 import { Redis } from "@upstash/redis";
+import { publish } from "./ablyClient.js";
 
 const LOG_TTL = 60 * 60 * 24 * 30; // 30 days
 
@@ -24,6 +25,8 @@ export async function handler(event) {
   await redis.lpush(prefix + "log:entered", JSON.stringify({ ticket: ticketNumber, ts, name }));
   await redis.ltrim(prefix + "log:entered", 0, 999);
   await redis.expire(prefix + "log:entered", LOG_TTL);
+
+  await publish(tenantId, "entered", { ticket: ticketNumber, ts, name });
 
   return {
     statusCode: 200,

--- a/functions/reset.js
+++ b/functions/reset.js
@@ -1,4 +1,5 @@
 import { Redis } from "@upstash/redis";
+import { publish } from "./ablyClient.js";
 
 const LOG_TTL = 60 * 60 * 24 * 30; // 30 days
 
@@ -47,6 +48,8 @@ export async function handler(event) {
   );
   await redis.ltrim(prefix + "log:reset", 0, 999);
   await redis.expire(prefix + "log:reset", LOG_TTL);
+
+  await publish(tenantId, "reset", { attendant, ts });
 
   return {
     statusCode: 200,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "@upstash/redis": "^1.20.0",
     "uuid": "^9.0.0",
     "bcryptjs": "^2.4.3",
-    "faunadb": "^4.6.0"
+    "faunadb": "^4.6.0",
+    "ably": "^1.2.9"
   },
   "engines": {
     "node": ">=16"

--- a/public/client/index.html
+++ b/public/client/index.html
@@ -37,6 +37,7 @@
     <button id="btn-start">Toque para ativar alertas</button>
   </div>
 
+  <script src="https://cdn.ably.io/lib/ably.min-1.js"></script>
   <script src="js/client.js"></script>
 </body>
 </html>

--- a/public/client/js/client.js
+++ b/public/client/js/client.js
@@ -28,7 +28,7 @@ const overlay    = document.getElementById("overlay");
 const alertSound = document.getElementById("alert-sound");
 
 let clientId, ticketNumber;
-let polling, alertInterval;
+let polling, alertInterval, ablyChannel;
 let lastEventTs = 0;
 let wakeLock = null;
 let silenced   = false;
@@ -93,7 +93,8 @@ btnStart.addEventListener("click", () => {
   btnCancel.hidden = false;
   btnCancel.disabled = false;
   getTicket();
-  polling = setInterval(checkStatus, 2000);
+  setupRealtime();
+  polling = setInterval(checkStatus, 10000);
 });
 
 async function getTicket() {
@@ -232,6 +233,13 @@ async function sendWelcomeNotification() {
   }
 }
 
+function setupRealtime() {
+  if (!tenantId || ablyChannel) return;
+  const realtime = new Ably.Realtime({ authUrl: `/.netlify/functions/ablyToken?t=${tenantId}` });
+  ablyChannel = realtime.channels.get(`tenant:${tenantId}`);
+  ablyChannel.subscribe(() => checkStatus());
+}
+
 btnSilence.addEventListener("click", () => {
   silenced = true;
   clearInterval(alertInterval);
@@ -263,5 +271,6 @@ btnCancel.addEventListener("click", async () => {
 btnJoin.addEventListener("click", () => {
   btnJoin.disabled = true;
   getTicket();
-  polling = setInterval(checkStatus, 2000);
+  setupRealtime();
+  polling = setInterval(checkStatus, 10000);
 });

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -131,6 +131,7 @@
     </section>
   </main>
 
+  <script src="https://cdn.ably.io/lib/ably.min-1.js"></script>
   <script src="js/monitor-attendant.js"></script>
 
   <!-- Modal de Relatório -->

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -123,6 +123,7 @@ document.addEventListener('DOMContentLoaded', () => {
   qrOverlay.appendChild(qrOverlayContent);
   document.body.appendChild(qrOverlay);
 
+  let ablyChannel;
   let currentCallNum = 0; // último número chamado exibido
   let ticketNames    = {};
   let ticketCounter  = 0;
@@ -344,6 +345,13 @@ function startBouncingCompanyName(text) {
 
   function refreshAll(t) {
     fetchStatus(t).then(() => { fetchCancelled(t); fetchAttended(t); });
+  }
+
+  function setupRealtime(t) {
+    if (!t || ablyChannel) return;
+    const realtime = new Ably.Realtime({ authUrl: '/.netlify/functions/ablyToken?t=' + t });
+    ablyChannel = realtime.channels.get('tenant:' + t);
+    ablyChannel.subscribe(() => refreshAll(t));
   }
 
   async function openReport(t) {
@@ -649,7 +657,8 @@ function startBouncingCompanyName(text) {
     };
     renderQRCode(t);
     refreshAll(t);
-    setInterval(() => refreshAll(t), 5000);
+    setupRealtime(t);
+    setInterval(() => refreshAll(t), 10000);
   }
 
   /** Exibe a interface principal após autenticação */

--- a/public/monitor/index.html
+++ b/public/monitor/index.html
@@ -25,6 +25,7 @@
   </div>
   <div id="unlock-overlay">Clique ou toque para ativar o som</div>
    <audio id="alert-sound" preload="auto" src="/sounds/alert.mp3"></audio>
+  <script src="https://cdn.ably.io/lib/ably.min-1.js"></script>
   <script src="js/monitor.js"></script>
 </body>
 </html>

--- a/public/monitor/js/monitor.js
+++ b/public/monitor/js/monitor.js
@@ -16,6 +16,7 @@ let lastId   = '';
 const alertSound   = document.getElementById('alert-sound');
 const unlockOverlay = document.getElementById('unlock-overlay');
 let wakeLock = null;
+let ablyChannel;
 
 // Desbloqueia o audio na primeira interação do usuário para evitar
 // que o navegador bloqueie a execução do som de alerta
@@ -114,8 +115,16 @@ async function fetchCurrent() {
   }
 }
 
+function setupRealtime() {
+  if (!tenantId || ablyChannel) return;
+  const realtime = new Ably.Realtime({ authUrl: '/.netlify/functions/ablyToken?t=' + tenantId });
+  ablyChannel = realtime.channels.get('tenant:' + tenantId);
+  ablyChannel.subscribe(fetchCurrent);
+}
+
 // Polling a cada 2 segundos
 fetchCurrent();
-setInterval(fetchCurrent, 2000);
+setupRealtime();
+setInterval(fetchCurrent, 10000);
 
 requestWakeLock();


### PR DESCRIPTION
## Summary
- install Ably SDK
- create helper and token functions for Ably
- publish queue events to Ably channels
- subscribe to Ably in client and monitor UIs
- reduce polling frequency

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861c2ca22a08329ae3244949930cff0