### PR TITLE
Implement long polling on frontend

### DIFF
--- a/public/monitor/js/monitor.js
+++ b/public/monitor/js/monitor.js
@@ -16,6 +16,8 @@ let lastId   = '';
 const alertSound   = document.getElementById('alert-sound');
 const unlockOverlay = document.getElementById('unlock-overlay');
 let wakeLock = null;
+let polling,
+    pollingActive = false;
 
 // Desbloqueia o audio na primeira interação do usuário para evitar
 // que o navegador bloqueie a execução do som de alerta
@@ -114,8 +116,19 @@ async function fetchCurrent() {
   }
 }
 
-// Polling a cada 2 segundos
-fetchCurrent();
-setInterval(fetchCurrent, 4000);
+async function longPollCurrent() {
+  if (!pollingActive) return;
+  try {
+    await fetchCurrent();
+  } catch (e) {
+    console.error('long polling error', e);
+  } finally {
+    if (pollingActive) polling = setTimeout(longPollCurrent, 0);
+  }
+}
+
+// Inicia long polling
+pollingActive = true;
+longPollCurrent();
 
 requestWakeLock();


### PR DESCRIPTION
## Summary
- replace interval polling with long polling in client, monitor and attendant UIs

## Testing
- `node --check public/client/js/client.js`
- `node --check public/monitor/js/monitor.js`
- `node --check public/monitor-attendant/js/monitor-attendant.js`


------
https://chatgpt.com/codex/tasks/task_e_6862e3b23e088329a8e56b2d12cd7d1a