### PR TITLE
feat: show success message after creating monitor

### DIFF
--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -79,6 +79,11 @@ body {
   color: var(--danger);
   font-size: 0.875rem;
 }
+.success {
+  margin-top: 0.5rem;
+  color: var(--success);
+  font-size: 0.875rem;
+}
 #onboard-overlay[hidden] {
   display: none !important;
 }

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -32,6 +32,7 @@
       <input id="onboard-password" type="password" placeholder="Defina uma senha" autocomplete="new-password" />
       <button id="onboard-submit">Criar Monitor</button>
       <div id="onboard-error" class="error"></div>
+      <div id="onboard-success" class="success" hidden></div>
     </div>
   </div>
 

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -35,6 +35,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const onboardPassword = document.getElementById('onboard-password');
   const onboardSubmit   = document.getElementById('onboard-submit');
   const onboardError    = document.getElementById('onboard-error');
+  const onboardSuccess  = document.getElementById('onboard-success');
 
   const loginCompany  = document.getElementById('login-company');
   const loginPassword = document.getElementById('login-password');
@@ -779,7 +780,12 @@ function startBouncingCompanyName(text) {
         cfg = { token, empresa: label, senha: pw };
         localStorage.setItem('monitorConfig', JSON.stringify(cfg));
         history.replaceState(null, '', `/monitor-attendant/?t=${token}&empresa=${encodeURIComponent(label)}`);
-        showApp(label, token);
+        onboardSuccess.textContent = 'Monitor criado com sucesso!';
+        onboardSuccess.hidden = false;
+        setTimeout(() => {
+          onboardSuccess.hidden = true;
+          showApp(label, token);
+        }, 2000);
       } catch (e) {
         console.error(e);
         onboardError.textContent = 'Erro ao criar monitor.';


### PR DESCRIPTION
## Summary
- display success feedback after monitor onboarding
- add delay before showing app to surface confirmation
- style success messages in green

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4c851484c8329bb17c0ecd20d61df