### PR TITLE
Pause monitor polling when tab hidden

### DIFF
--- a/public/monitor/js/monitor.js
+++ b/public/monitor/js/monitor.js
@@ -16,6 +16,7 @@ let lastId   = '';
 const alertSound   = document.getElementById('alert-sound');
 const unlockOverlay = document.getElementById('unlock-overlay');
 let wakeLock = null;
+let intervalId = null;
 
 // Desbloqueia o audio na primeira interação do usuário para evitar
 // que o navegador bloqueie a execução do som de alerta
@@ -59,7 +60,15 @@ function releaseWakeLock() {
 }
 
 document.addEventListener('visibilitychange', () => {
-  if (!document.hidden) requestWakeLock();
+  if (document.hidden) {
+    clearInterval(intervalId);
+    intervalId = null;
+  } else {
+    requestWakeLock();
+    fetchCurrent();
+    clearInterval(intervalId);
+    intervalId = setInterval(fetchCurrent, 4000);
+  }
 });
 
 window.addEventListener('beforeunload', () => {
@@ -116,6 +125,6 @@ async function fetchCurrent() {
 
 // Polling a cada 4 segundos
 fetchCurrent();
-setInterval(fetchCurrent, 4000);
+intervalId = setInterval(fetchCurrent, 4000);
 
 requestWakeLock();


### PR DESCRIPTION
## Summary
- store interval ID for monitor polling
- pause polling when page is hidden and restart on visibility change

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5c7c4c5288329a2152934ce1752e8