### PR TITLE
Add printable QR code PDF to attendant panel

### DIFF
--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -580,6 +580,21 @@ body {
   margin-top: 0.5rem;
 }
 
+/* Botão de PDF do QR Code */
+.qrcode-wrapper {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+#btn-qr-pdf {
+  width: auto;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.8rem;
+  margin-bottom: 0;
+}
+
 /* Animação de expansão e fade */
 @keyframes ripple-effect {
   to {

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -97,7 +97,10 @@
     <!-- Seção de QR Code -->
     <section class="qrcode-panel">
       <h2>QR Code</h2>
-      <div id="qrcode"></div>
+      <div class="qrcode-wrapper">
+        <div id="qrcode"></div>
+        <button id="btn-qr-pdf" class="btn btn-secondary" hidden>PDF</button>
+      </div>
       <p>Aponte a câmera do celular para este QR para entrar na fila.</p>
     </section>
 


### PR DESCRIPTION
## Summary
- Add discrete PDF button near attendant QR code
- Generate printable PDF with queue QR and usage instructions
- Show button only when QR code is visible and style for clean UI

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7ed3fdadc8329a1f595b6f06e4600