### PR TITLE
feat: confirmar avanço com ticket ativo

### DIFF
--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -872,6 +872,10 @@ function startBouncingCompanyName(text) {
     });
 
     btnNext.onclick = async () => {
+      if (currentCallNum > 0 &&
+          !confirm('Ainda há um ticket sendo chamado. Avançar fará com que ele perca a vez. Continuar?')) {
+        return;
+      }
       const id = attendantInput.value.trim();
       let url = `/.netlify/functions/chamar?t=${t}`;
       if (id) url += `&id=${encodeURIComponent(id)}`;


### PR DESCRIPTION
## Summary
- Add confirmation when user clicks "Próximo" while a ticket is active, warning they will lose the current call

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8ca653c488329885ff36129d0c635