### PR TITLE
Expose password prompt in monitor-attendant error alerts

### DIFF
--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -982,11 +982,12 @@ function startBouncingCompanyName(text) {
     if (token && empresaParam) {
       loginOverlay.hidden   = true;
       onboardOverlay.hidden = true;
-      let senhaPrompt = cfg?.senha || senhaParam;
-      if (!senhaPrompt) {
-        senhaPrompt = prompt(`Digite a senha de acesso para a empresa ${empresaParam}:`);
-      }
+      let senhaPrompt;
       try {
+        senhaPrompt = cfg?.senha || senhaParam;
+        if (!senhaPrompt) {
+          senhaPrompt = prompt(`Digite a senha de acesso para a empresa ${empresaParam}:`);
+        }
         const res = await fetch(`${location.origin}/.netlify/functions/getMonitorConfig`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -996,16 +997,16 @@ function startBouncingCompanyName(text) {
         if (!res.ok) {
           alert(
             `Token ou senha inválidos.\n` +
-            `Senha correta (servidor): ${data?.senha ?? '(nenhuma)'}\n` +
+            `Senha correta (local): ${cfg?.senha ?? '(nenhuma)'}\n` +
             `Senha digitada: ${senhaPrompt}\n` +
-            `Token correto (servidor): ${data?.token ?? '(nenhum)'}\n` +
+            `Token correto (local): ${cfg?.token ?? '(nenhum)'}\n` +
             `Token enviado: ${token}`
           );
           history.replaceState(null, '', '/monitor-attendant/');
           return;
         }
-        const { empresa, schedule, senha: serverSenha } = data;
-        cfg = { token, empresa, senha: serverSenha, schedule };
+        const { empresa, schedule } = data;
+        cfg = { token, empresa, senha: senhaPrompt, schedule };
         localStorage.setItem('monitorConfig', JSON.stringify(cfg));
         history.replaceState(null, '', `/monitor-attendant/?empresa=${encodeURIComponent(empresaParam)}`);
         showApp(empresa, token);

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -967,8 +967,9 @@ function startBouncingCompanyName(text) {
     if (token && empresaParam) {
       loginOverlay.hidden   = true;
       onboardOverlay.hidden = true;
+      let senhaPrompt;
       try {
-        const senhaPrompt = senhaParam || prompt(`Digite a senha de acesso para a empresa ${empresaParam}:`);
+        senhaPrompt = senhaParam || prompt(`Digite a senha de acesso para a empresa ${empresaParam}:`);
         const res = await fetch(`${location.origin}/.netlify/functions/getMonitorConfig`, {
           method: 'POST',
           headers: {'Content-Type':'application/json'},
@@ -982,7 +983,13 @@ function startBouncingCompanyName(text) {
         showApp(empresa, token);
         return;
       } catch {
-        alert('Token ou senha inválidos.');
+        alert(
+          `Token ou senha inválidos.\n` +
+          `Senha correta (local): ${cfg?.senha ?? '(nenhuma)'}\n` +
+          `Senha digitada: ${senhaPrompt}\n` +
+          `Token correto (local): ${cfg?.token ?? '(nenhum)'}\n` +
+          `Token enviado: ${token}`
+        );
         history.replaceState(null, '', '/monitor-attendant/');
       }
     }


### PR DESCRIPTION
## Summary
- Ensure prompt-entered password is accessible in catch block
- Provide detailed alert when token or password validation fails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa59b6a3e88329b944be0c40b94b0e