### PR TITLE
Add attendant clone management and forced logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Funções serverless e front-end para a fila virtual SuaVez.
 A função `deleteMonitorConfig` apaga o registro do monitor e **todas** as chaves `tenant:{token}:*` associadas no Redis.
 Esse reset remove contadores, senha, label, tickets e logs, utilizando `SCAN`/`DEL` para eliminar também conjuntos e hashes da fila.
 
-Após o reset, todos os links do monitor e do cliente ficam inválidos e nenhum dado da fila é preservado..
+Após o reset, todos os links do monitor e do cliente ficam inválidos e nenhum dado da fila é preservado.

--- a/functions/cancelClone.js
+++ b/functions/cancelClone.js
@@ -8,7 +8,6 @@ export async function handler(event) {
     }
     const redis = Redis.fromEnv();
     await redis.srem(`tenant:${token}:clones`, cloneId);
-    await redis.incr(`tenant:${token}:logoutVersion`);
     return { statusCode: 200, body: JSON.stringify({ ok: true }) };
   } catch (e) {
     console.error('cancelClone error', e);

--- a/functions/cancelClone.js
+++ b/functions/cancelClone.js
@@ -1,0 +1,17 @@
+import { Redis } from '@upstash/redis';
+
+export async function handler(event) {
+  try {
+    const { token, cloneId } = JSON.parse(event.body || '{}');
+    if (!token || !cloneId) {
+      return { statusCode: 400, body: JSON.stringify({ error: 'Missing fields' }) };
+    }
+    const redis = Redis.fromEnv();
+    await redis.srem(`tenant:${token}:clones`, cloneId);
+    await redis.incr(`tenant:${token}:logoutVersion`);
+    return { statusCode: 200, body: JSON.stringify({ ok: true }) };
+  } catch (e) {
+    console.error('cancelClone error', e);
+    return { statusCode: 500, body: JSON.stringify({ error: 'Server error' }) };
+  }
+}

--- a/functions/changePassword.js
+++ b/functions/changePassword.js
@@ -1,0 +1,27 @@
+import { Redis } from '@upstash/redis';
+import bcrypt from 'bcryptjs';
+
+export async function handler(event) {
+  try {
+    const { token, senhaAtual, novaSenha } = JSON.parse(event.body || '{}');
+    if (!token || !senhaAtual || !novaSenha) {
+      return { statusCode: 400, body: JSON.stringify({ error: 'Missing fields' }) };
+    }
+    const redis = Redis.fromEnv();
+    const pwHash = await redis.get(`tenant:${token}:pwHash`);
+    if (!pwHash) {
+      return { statusCode: 404, body: JSON.stringify({ error: 'Invalid token' }) };
+    }
+    const valid = await bcrypt.compare(senhaAtual, pwHash);
+    if (!valid) {
+      return { statusCode: 403, body: JSON.stringify({ error: 'Senha atual incorreta' }) };
+    }
+    const newHash = await bcrypt.hash(novaSenha, 10);
+    await redis.set(`tenant:${token}:pwHash`, newHash);
+    await redis.incr(`tenant:${token}:logoutVersion`);
+    return { statusCode: 200, body: JSON.stringify({ ok: true }) };
+  } catch (e) {
+    console.error('changePassword error', e);
+    return { statusCode: 500, body: JSON.stringify({ error: 'Server error' }) };
+  }
+}

--- a/functions/listClones.js
+++ b/functions/listClones.js
@@ -1,0 +1,17 @@
+import { Redis } from '@upstash/redis';
+
+export async function handler(event) {
+  try {
+    const url = new URL(event.rawUrl);
+    const token = url.searchParams.get('t');
+    if (!token) {
+      return { statusCode: 400, body: JSON.stringify({ error: 'Missing token' }) };
+    }
+    const redis = Redis.fromEnv();
+    const clones = await redis.smembers(`tenant:${token}:clones`);
+    return { statusCode: 200, body: JSON.stringify({ clones }) };
+  } catch (e) {
+    console.error('listClones error', e);
+    return { statusCode: 500, body: JSON.stringify({ error: 'Server error' }) };
+  }
+}

--- a/functions/registerClone.js
+++ b/functions/registerClone.js
@@ -1,0 +1,16 @@
+import { Redis } from '@upstash/redis';
+
+export async function handler(event) {
+  try {
+    const { token, cloneId } = JSON.parse(event.body || '{}');
+    if (!token || !cloneId) {
+      return { statusCode: 400, body: JSON.stringify({ error: 'Missing fields' }) };
+    }
+    const redis = Redis.fromEnv();
+    await redis.sadd(`tenant:${token}:clones`, cloneId);
+    return { statusCode: 200, body: JSON.stringify({ ok: true }) };
+  } catch (e) {
+    console.error('registerClone error', e);
+    return { statusCode: 500, body: JSON.stringify({ error: 'Server error' }) };
+  }
+}

--- a/functions/registerMonitor.js
+++ b/functions/registerMonitor.js
@@ -23,6 +23,8 @@ export async function handler(event) {
     await redis.set(`tenant:${tenantId}:callCounter`,  0);
     await redis.set(`tenant:${tenantId}:currentCall`,  0);
     await redis.set(`tenant:${tenantId}:currentCallTs`, Date.now());
+    await redis.set(`tenant:${tenantId}:logoutVersion`, 0);
+    await redis.del(`tenant:${tenantId}:clones`);
 
     return {
       statusCode: 200,

--- a/functions/status.js
+++ b/functions/status.js
@@ -17,13 +17,14 @@ export async function handler(event) {
   }
   const prefix = `tenant:${tenantId}:`;
 
-  const [currentCallRaw, callCounterRaw, ticketCounterRaw, attendantRaw, timestampRaw] =
+  const [currentCallRaw, callCounterRaw, ticketCounterRaw, attendantRaw, timestampRaw, logoutVersionRaw] =
     await redis.mget(
       prefix + "currentCall",
       prefix + "callCounter",
       prefix + "ticketCounter",
       prefix + "currentAttendant",
-      prefix + "currentCallTs"
+      prefix + "currentCallTs",
+      prefix + "logoutVersion"
     );
   const currentCall   = Number(currentCallRaw || 0);
   const callCounter   = Number(callCounterRaw || 0);
@@ -60,6 +61,7 @@ export async function handler(event) {
       attendedCount,
       waiting,
       names: nameMap || {},
+      logoutVersion: Number(logoutVersionRaw || 0),
     }),
   };
 }

--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -657,6 +657,37 @@ body {
   margin-bottom: 0;
 }
 
+/* Painel administrativo lateral */
+.admin-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 220px;
+  height: 100%;
+  background: #fff;
+  border-left: 2px solid var(--primary);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  box-shadow: -2px 0 5px rgba(0,0,0,0.1);
+  z-index: 150;
+}
+
+.admin-panel h3 {
+  margin-bottom: 0.5rem;
+  color: var(--primary);
+  font-size: 1rem;
+}
+
+.admin-panel[hidden] {
+  display: none;
+}
+
+#admin-toggle {
+  margin-left: auto;
+}
+
 /* Animação de expansão e fade */
 @keyframes ripple-effect {
   to {

--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -580,6 +580,36 @@ body {
   margin: 1rem auto;
 }
 
+#clone-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+#clone-modal[hidden] {
+  display: none !important;
+}
+#clone-modal .modal-content {
+  background: #fff;
+  padding: 1rem;
+  border-radius: var(--radius);
+  width: 90%;
+  max-width: 400px;
+  text-align: center;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.3);
+}
+#clone-modal .close {
+  float: right;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+#clone-qrcode {
+  margin: 1rem auto;
+}
+
 /* Modal de edição de horário */
 #schedule-modal {
   position: fixed;

--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -76,6 +76,9 @@ body {
   font-size: 1rem;
   cursor: pointer;
 }
+#onboard-submit {
+  margin-bottom: 1rem;
+}
 .onboard-box .error {
   margin-top: 0.5rem;
   color: var(--danger);

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -94,6 +94,12 @@
   <button id="btn-edit-schedule" class="btn btn-secondary">
     Editar Horário
   </button>
+  <button id="btn-clone" class="btn btn-secondary">
+    Clonar Atendente
+  </button>
+  <button id="btn-change-password" class="btn btn-secondary">
+    Trocar Senha
+  </button>
 </header>
 
   <!-- Conteúdo Principal -->
@@ -106,6 +112,11 @@
         <button id="btn-qr-pdf" class="btn btn-secondary" hidden>PDF</button>
       </div>
       <p>Aponte a câmera do celular para este QR para entrar na fila.</p>
+    </section>
+
+    <section class="clones-panel">
+      <h2>Clones</h2>
+      <ul id="clone-list" class="list"></ul>
     </section>
 
     <!-- Painel de Identificador -->
@@ -220,6 +231,28 @@
       <div id="view-qrcode"></div>
       <p>Escaneie para visualizar apenas o painel.</p>
       <p id="view-copy-info" class="copy-info" hidden>Link copiado para a área de transferência.</p>
+    </div>
+  </div>
+
+  <!-- Modal para Clonar Atendente -->
+  <div id="clone-modal" hidden>
+    <div class="modal-content">
+      <span id="clone-close" class="close">&times;</span>
+      <h2>Clonar Atendente</h2>
+      <div id="clone-qrcode"></div>
+      <p id="clone-copy-info" class="copy-info" hidden>Link copiado para a área de transferência.</p>
+    </div>
+  </div>
+
+  <!-- Modal de Troca de Senha -->
+  <div id="password-modal" hidden>
+    <div class="onboard-box">
+      <span id="password-close" class="close">&times;</span>
+      <h2>Trocar Senha</h2>
+      <input id="password-current" type="password" placeholder="Senha Atual" />
+      <input id="password-new" type="password" placeholder="Nova Senha" />
+      <button id="password-save">Salvar</button>
+      <div id="password-error" class="error"></div>
     </div>
   </div>
 

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -241,6 +241,7 @@
       <span id="clone-close" class="close">&times;</span>
       <h2>Clonar Atendente</h2>
       <div id="clone-qrcode"></div>
+      <p>Escaneie para duplicar esta tela de atendimento.</p>
       <p id="clone-copy-info" class="copy-info" hidden>Link copiado para a área de transferência.</p>
     </div>
   </div>

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -86,21 +86,15 @@
       <span id="header-schedule" class="header-schedule"></span>
     </div>
   </div>
-  <button id="btn-delete-config" class="btn btn-secondary">
-    Redefinir Cadastro
-  </button>
-  <button id="btn-view-monitor" class="btn btn-secondary">
-    Espelhar Monitor
-  </button>
-  <button id="btn-edit-schedule" class="btn btn-secondary">
-    Editar Horário
-  </button>
-  <button id="btn-clone" class="btn btn-secondary">
-    Clonar Atendente
-  </button>
-  <button id="btn-change-password" class="btn btn-secondary">
-    Trocar Senha
-  </button>
+  <button id="admin-toggle" class="btn btn-secondary" aria-label="Administração">⚙️</button>
+  <nav id="admin-panel" class="admin-panel" hidden>
+    <h3>Administração</h3>
+    <button id="btn-delete-config" class="btn btn-secondary">Redefinir Cadastro</button>
+    <button id="btn-view-monitor" class="btn btn-secondary">Espelhar Monitor</button>
+    <button id="btn-edit-schedule" class="btn btn-secondary">Editar Horário</button>
+    <button id="btn-clone" class="btn btn-secondary">Clonar Atendente</button>
+    <button id="btn-change-password" class="btn btn-secondary">Trocar Senha</button>
+  </nav>
 </header>
 
   <!-- Conteúdo Principal -->

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -55,6 +55,7 @@
         </div>
       </fieldset>
       <button id="onboard-submit">Criar Monitor</button>
+      <button id="onboard-login" class="btn btn-secondary">Entrar</button>
       <div id="onboard-error" class="error"></div>
     </div>
   </div>

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -55,7 +55,7 @@
         </div>
       </fieldset>
       <button id="onboard-submit">Criar Monitor</button>
-      <button id="onboard-login" class="btn btn-secondary">Entrar</button>
+      <button id="onboard-login" class="btn btn-success">Entrar</button>
       <div id="onboard-error" class="error"></div>
     </div>
   </div>

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -54,7 +54,7 @@
           <input id="end2" type="time" value="18:00" />
         </div>
       </fieldset>
-      <button id="onboard-submit">Criar Monitor</button>
+      <button id="onboard-submit" class="btn">Criar Monitor</button>
       <button id="onboard-login" class="btn btn-success">Entrar</button>
       <div id="onboard-error" class="error"></div>
     </div>

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -148,6 +148,16 @@ document.addEventListener('DOMContentLoaded', () => {
   const btnEditSchedule= document.getElementById('btn-edit-schedule');
   const btnClone       = document.getElementById('btn-clone');
   const btnChangePw    = document.getElementById('btn-change-password');
+  const adminToggle    = document.getElementById('admin-toggle');
+  const adminPanel     = document.getElementById('admin-panel');
+  adminToggle?.addEventListener('click', () => {
+    adminPanel.hidden = !adminPanel.hidden;
+  });
+  document.addEventListener('click', (e) => {
+    if (!adminPanel.hidden && !adminPanel.contains(e.target) && e.target !== adminToggle) {
+      adminPanel.hidden = true;
+    }
+  });
   const reportModal    = document.getElementById('report-modal');
   const reportClose    = document.getElementById('report-close');
   const reportTitle    = document.getElementById('report-title');

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -15,7 +15,12 @@ document.addEventListener('DOMContentLoaded', () => {
   let token           = urlParams.get('t');
   let empresaParam    = urlParams.get('empresa');
   let senhaParam      = urlParams.get('senha');
-  const isClone       = urlParams.get('clone') === '1';
+  let isClone         = urlParams.get('clone') === '1' || localStorage.getItem('isClone') === '1';
+  if (isClone) {
+    localStorage.setItem('isClone', '1');
+  } else {
+    localStorage.removeItem('isClone');
+  }
   const storedConfig  = localStorage.getItem('monitorConfig');
   let cfg             = storedConfig ? JSON.parse(storedConfig) : null;
   let logoutVersion   = localStorage.getItem('logoutVersion');

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -527,7 +527,7 @@ function startBouncingCompanyName(text) {
 
       if (logoutVersion !== null && srvLogoutVersion !== logoutVersion) {
         localStorage.clear();
-        location.href = '/monitor-attendant/';
+        location.href = isClone ? '/monitor-attendant/?clone=1' : '/monitor-attendant/';
         return;
       }
       logoutVersion = srvLogoutVersion;
@@ -984,10 +984,18 @@ function startBouncingCompanyName(text) {
   }
 
   async function loadCloneList(t) {
-    if (isClone || !cloneListEl) return;
+    if (!t) return;
     try {
       const res = await fetch(`/.netlify/functions/listClones?t=${t}`);
       const { clones = [] } = await res.json();
+      if (isClone) {
+        if (!clones.includes(cloneId)) {
+          localStorage.clear();
+          location.href = '/monitor-attendant/?clone=1';
+        }
+        return;
+      }
+      if (!cloneListEl) return;
       cloneListEl.innerHTML = '';
       clones.filter(c => c !== cloneId).forEach(id => {
         const li = document.createElement('li');

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -532,7 +532,8 @@ function startBouncingCompanyName(text) {
 
       if (logoutVersion !== null && srvLogoutVersion !== logoutVersion) {
         localStorage.clear();
-        location.href = isClone ? '/monitor-attendant/?clone=1' : '/monitor-attendant/';
+        history.replaceState(null, '', '/');
+        location.href = '/';
         return;
       }
       logoutVersion = srvLogoutVersion;
@@ -996,7 +997,8 @@ function startBouncingCompanyName(text) {
       if (isClone) {
         if (!clones.includes(cloneId)) {
           localStorage.clear();
-          location.href = '/monitor-attendant/?clone=1';
+          history.replaceState(null, '', '/');
+          location.href = '/';
         }
         return;
       }


### PR DESCRIPTION
## Summary
- Enable cloning attendants with QR link and clipboard copy
- Hide admin controls for clone sessions and monitor logout version
- Add Redis functions to register, list, cancel clones and change password

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab5e82e6d483299c90dddbd614c6e3