### PR TITLE
feat: add admin panel

### DIFF
--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -657,6 +657,54 @@ body {
   margin-bottom: 0;
 }
 
+/* Painel administrativo lateral */
+.admin-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 220px;
+  height: 100%;
+  background: #fff;
+  border-left: 2px solid var(--primary);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  box-shadow: -2px 0 5px rgba(0,0,0,0.1);
+  z-index: 150;
+}
+
+.admin-panel h3 {
+  margin-bottom: 0.5rem;
+  color: var(--primary);
+  font-size: 1rem;
+}
+
+.admin-panel .clones-panel {
+  margin-top: 0.75rem;
+  border-top: 1px solid #eee;
+  padding-top: 0.5rem;
+}
+
+.admin-panel .clones-panel h4 {
+  font-size: 0.95rem;
+  margin-bottom: 0.5rem;
+  color: var(--primary);
+}
+
+.admin-panel #clone-list {
+  max-height: 7.5rem; /* approx 3 items */
+  overflow-y: auto;
+}
+
+.admin-panel[hidden] {
+  display: none;
+}
+
+#admin-toggle {
+  margin-left: auto;
+}
+
 /* Animação de expansão e fade */
 @keyframes ripple-effect {
   to {

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -86,21 +86,19 @@
       <span id="header-schedule" class="header-schedule"></span>
     </div>
   </div>
-  <button id="btn-delete-config" class="btn btn-secondary">
-    Redefinir Cadastro
-  </button>
-  <button id="btn-view-monitor" class="btn btn-secondary">
-    Espelhar Monitor
-  </button>
-  <button id="btn-edit-schedule" class="btn btn-secondary">
-    Editar Horário
-  </button>
-  <button id="btn-clone" class="btn btn-secondary">
-    Clonar Atendente
-  </button>
-  <button id="btn-change-password" class="btn btn-secondary">
-    Trocar Senha
-  </button>
+  <button id="admin-toggle" class="btn btn-secondary" aria-label="Administração">⚙️</button>
+  <nav id="admin-panel" class="admin-panel" hidden>
+    <h3>Administração</h3>
+    <button id="btn-delete-config" class="btn btn-secondary">Redefinir Cadastro</button>
+    <button id="btn-view-monitor" class="btn btn-secondary">Espelhar Monitor</button>
+    <button id="btn-edit-schedule" class="btn btn-secondary">Editar Horário</button>
+    <button id="btn-clone" class="btn btn-secondary">Clonar Atendente</button>
+    <button id="btn-change-password" class="btn btn-secondary">Trocar Senha</button>
+    <div class="clones-panel">
+      <h4>Clones</h4>
+      <ul id="clone-list" class="list"></ul>
+    </div>
+  </nav>
 </header>
 
   <!-- Conteúdo Principal -->
@@ -113,11 +111,6 @@
         <button id="btn-qr-pdf" class="btn btn-secondary" hidden>PDF</button>
       </div>
       <p>Aponte a câmera do celular para este QR para entrar na fila.</p>
-    </section>
-
-    <section class="clones-panel">
-      <h2>Clones</h2>
-      <ul id="clone-list" class="list"></ul>
     </section>
 
     <!-- Painel de Identificador -->

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -148,6 +148,16 @@ document.addEventListener('DOMContentLoaded', () => {
   const btnEditSchedule= document.getElementById('btn-edit-schedule');
   const btnClone       = document.getElementById('btn-clone');
   const btnChangePw    = document.getElementById('btn-change-password');
+  const adminToggle    = document.getElementById('admin-toggle');
+  const adminPanel     = document.getElementById('admin-panel');
+  adminToggle?.addEventListener('click', () => {
+    adminPanel.hidden = !adminPanel.hidden;
+  });
+  document.addEventListener('click', (e) => {
+    if (!adminPanel.hidden && !adminPanel.contains(e.target) && e.target !== adminToggle) {
+      adminPanel.hidden = true;
+    }
+  });
   const reportModal    = document.getElementById('report-modal');
   const reportClose    = document.getElementById('report-close');
   const reportTitle    = document.getElementById('report-title');


### PR DESCRIPTION
## Summary
- add collapsible admin panel with administrative actions
- style new admin panel and toggle
- handle panel visibility in attendant monitor script
- embed clone management list in admin panel with scroll limit

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac791455248329aa631e29cbd1cbd0