### PR TITLE
Alinha modal de senha e habilita fullscreen do monitor

### DIFF
--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -613,6 +613,56 @@ body {
   margin: 1rem auto;
 }
 
+/* Modal de troca de senha */
+#password-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+#password-modal[hidden] {
+  display: none !important;
+}
+#password-modal .modal-content {
+  background: #fff;
+  padding: 1rem;
+  border-radius: var(--radius);
+  width: 90%;
+  max-width: 400px;
+  text-align: center;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.3);
+}
+#password-modal .close {
+  float: right;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+#password-modal input {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: var(--radius);
+  margin: 0.5rem 0;
+}
+#password-modal button {
+  width: 100%;
+  padding: 0.75rem;
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius);
+  cursor: pointer;
+  font-size: 1rem;
+}
+#password-modal .error {
+  color: var(--danger);
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+}
+
 /* Modal de edição de horário */
 #schedule-modal {
   position: fixed;

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -241,7 +241,7 @@
 
   <!-- Modal de Troca de Senha -->
   <div id="password-modal" hidden>
-    <div class="onboard-box">
+    <div class="modal-content">
       <span id="password-close" class="close">&times;</span>
       <h2>Trocar Senha</h2>
       <input id="password-current" type="password" placeholder="Senha Atual" />

--- a/public/monitor/js/monitor.js
+++ b/public/monitor/js/monitor.js
@@ -32,11 +32,14 @@ if (alertSound) {
     }
     alertSound.volume = 1;
     requestWakeLock();
+    if (document.documentElement.requestFullscreen) {
+      document.documentElement.requestFullscreen().catch(() => {});
+    }
     if (unlockOverlay) unlockOverlay.classList.add('hidden');
     document.removeEventListener('click', unlock);
     document.removeEventListener('touchstart', unlock);
     if (unlockOverlay) unlockOverlay.removeEventListener('click', unlock);
-  };
+    };
   document.addEventListener('click', unlock, { once: true });
   document.addEventListener('touchstart', unlock, { once: true });
   if (unlockOverlay) unlockOverlay.addEventListener('click', unlock);


### PR DESCRIPTION
## Summary
- Ajusta modal de troca de senha para usar o mesmo estilo do modal de espelhamento do monitor
- Solicita tela cheia ao desbloquear o monitor espelhado

## Testing
- `npm test` (missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acb95ef1788329996df4be2fd59488