### PR TITLE
Corrige corte de texto no painel de administração em modo paisagem

### DIFF
--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -747,6 +747,10 @@ body {
   overflow-y: auto;
 }
 
+.admin-panel .btn {
+  white-space: normal;
+}
+
 .admin-panel[hidden] {
   display: none;
 }

--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -754,8 +754,11 @@ body {
 }
 
 .admin-panel .btn {
-  white-space: normal;
+  display: block;
+  white-space: normal !important;
+  word-break: break-word;
   overflow-wrap: anywhere;
+  overflow: visible;
 }
 
 .admin-panel[hidden] {

--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -722,6 +722,7 @@ body {
   gap: 0.5rem;
   box-shadow: -2px 0 5px rgba(0,0,0,0.1);
   z-index: 150;
+  overflow-y: auto;
 }
 
 .admin-panel h3 {
@@ -745,10 +746,16 @@ body {
 .admin-panel #clone-list {
   max-height: 7.5rem; /* approx 3 items */
   overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.admin-panel #clone-list li {
+  display: block;
 }
 
 .admin-panel .btn {
   white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .admin-panel[hidden] {


### PR DESCRIPTION
## Summary
- evita que textos dos botões do painel administrativo sejam cortados em telas estreitas

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68af0d88fb9083298e0b2dc6b7d2f007