### PR TITLE
feat: call tickets from attendant queue

### DIFF
--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -242,6 +242,19 @@ body {
   color: var(--primary);
   margin-bottom: 0.5rem;
 }
+#queue-list li {
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius);
+  transition: background 0.2s;
+}
+#queue-list li:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+#queue-list li.selected {
+  background: var(--secondary);
+  color: #fff;
+}
 .display {
   font-size: 1.5rem;
   margin-bottom: 0.75rem;

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -523,11 +523,8 @@ function startBouncingCompanyName(text) {
     if (!queueListEl) return;
     queueListEl.innerHTML = '';
     const pending = [];
-    // Se a chamada atual for maior que o contador sequencial, significa que
-    // houve um "fura-fila" manual. Nesse caso, incluímos também o número do
-    // contador atual na fila para que ele permaneça pendente.
-    const start = currentCallNum > callCounter ? callCounter : callCounter + 1;
-    for (let i = Math.max(1, start); i <= ticketCounter; i++) {
+    // Lista os tickets pendentes a partir do próximo número sequencial
+    for (let i = Math.max(1, callCounter + 1); i <= ticketCounter; i++) {
       if (i === currentCallNum) continue;
       if (cancelledNums.includes(i) || missedNums.includes(i) || attendedNums.includes(i)) continue;
       pending.push(i);
@@ -1090,10 +1087,9 @@ function startBouncingCompanyName(text) {
           !confirm('Ainda há um ticket sendo chamado. Avançar fará com que ele perca a vez. Continuar?')) {
         return;
       }
-      const nextTicket = pendingQueue[0];
-      if (!nextTicket) return;
+      if (!pendingQueue.length) return;
       const id = attendantInput.value.trim();
-      let url = `/.netlify/functions/chamar?t=${t}&num=${nextTicket}`;
+      let url = `/.netlify/functions/chamar?t=${t}`;
       if (id) url += `&id=${encodeURIComponent(id)}`;
       const { called, attendant } = await (await fetch(url)).json();
       updateCall(called, attendant);

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -143,6 +143,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const attendedThumbsEl = document.getElementById('attended-thumbs');
   const attendedCountEl  = document.getElementById('attended-count');
   const queueListEl    = document.getElementById('queue-list');
+  const selectSound    = new Audio('/sounds/alert.mp3');
   const btnNext        = document.getElementById('btn-next');
   const btnRepeat      = document.getElementById('btn-repeat');
   const btnAttended    = document.getElementById('btn-attended');
@@ -528,8 +529,26 @@ function startBouncingCompanyName(text) {
     }
     pending.forEach(n => {
       const li = document.createElement('li');
+      li.dataset.ticket = n;
       const nm = ticketNames[n];
       li.textContent = nm ? `${n} - ${nm}` : String(n);
+      li.addEventListener('click', async () => {
+        const ticket = li.dataset.ticket;
+        const id = attendantInput.value.trim();
+        let url = `/.netlify/functions/chamar?t=${token}&num=${ticket}`;
+        if (id) url += `&id=${encodeURIComponent(id)}`;
+        try {
+          const { called, attendant } = await (await fetch(url)).json();
+          updateCall(called, attendant);
+          refreshAll(token);
+          li.classList.add('selected');
+          selectSound.currentTime = 0;
+          selectSound.play().catch(() => {});
+          setTimeout(() => li.classList.remove('selected'), 600);
+        } catch (e) {
+          console.error(e);
+        }
+      });
       queueListEl.appendChild(li);
     });
   }

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -522,7 +522,11 @@ function startBouncingCompanyName(text) {
     if (!queueListEl) return;
     queueListEl.innerHTML = '';
     const pending = [];
-    for (let i = callCounter + 1; i <= ticketCounter; i++) {
+    // Se a chamada atual for maior que o contador sequencial, significa que
+    // houve um "fura-fila" manual. Nesse caso, incluímos também o número do
+    // contador atual na fila para que ele permaneça pendente.
+    const start = currentCallNum > callCounter ? callCounter : callCounter + 1;
+    for (let i = Math.max(1, start); i <= ticketCounter; i++) {
       if (i === currentCallNum) continue;
       if (cancelledNums.includes(i) || missedNums.includes(i) || attendedNums.includes(i)) continue;
       pending.push(i);

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -361,6 +361,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let missedCount    = 0;
   let attendedNums   = [];
   let attendedCount  = 0;
+  let pendingQueue   = [];
   let pollingId;
   const fmtTime     = ts => new Date(ts).toLocaleString('pt-BR');
   const msToHms = (ms) => {
@@ -531,13 +532,15 @@ function startBouncingCompanyName(text) {
       if (cancelledNums.includes(i) || missedNums.includes(i) || attendedNums.includes(i)) continue;
       pending.push(i);
     }
+    pendingQueue = pending;
     pending.forEach(n => {
       const li = document.createElement('li');
       li.dataset.ticket = n;
       const nm = ticketNames[n];
       li.textContent = nm ? `${n} - ${nm}` : String(n);
       li.addEventListener('click', async () => {
-        const ticket = li.dataset.ticket;
+        const ticket = Number(li.dataset.ticket);
+        if (!pendingQueue.includes(ticket)) return;
         const id = attendantInput.value.trim();
         let url = `/.netlify/functions/chamar?t=${token}&num=${ticket}`;
         if (id) url += `&id=${encodeURIComponent(id)}`;
@@ -1087,8 +1090,10 @@ function startBouncingCompanyName(text) {
           !confirm('Ainda há um ticket sendo chamado. Avançar fará com que ele perca a vez. Continuar?')) {
         return;
       }
+      const nextTicket = pendingQueue[0];
+      if (!nextTicket) return;
       const id = attendantInput.value.trim();
-      let url = `/.netlify/functions/chamar?t=${t}`;
+      let url = `/.netlify/functions/chamar?t=${t}&num=${nextTicket}`;
       if (id) url += `&id=${encodeURIComponent(id)}`;
       const { called, attendant } = await (await fetch(url)).json();
       updateCall(called, attendant);

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -523,8 +523,9 @@ function startBouncingCompanyName(text) {
     if (!queueListEl) return;
     queueListEl.innerHTML = '';
     const pending = [];
-    // Lista os tickets pendentes a partir do próximo número sequencial
-    for (let i = Math.max(1, callCounter + 1); i <= ticketCounter; i++) {
+    // Lista todos os tickets ainda pendentes, preservando os menores
+    // números quando um ticket posterior é chamado manualmente
+    for (let i = 1; i <= ticketCounter; i++) {
       if (i === currentCallNum) continue;
       if (cancelledNums.includes(i) || missedNums.includes(i) || attendedNums.includes(i)) continue;
       pending.push(i);


### PR DESCRIPTION
## Summary
- make queue items clickable to call specific ticket
- style queue list items with pointer and selection feedback

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0428ef9788329a8791f0e5f839157