### PR TITLE
Implement Redis rate limiting for public routes

### DIFF
--- a/functions/utils/rateLimit.js
+++ b/functions/utils/rateLimit.js
@@ -1,0 +1,14 @@
+const LIMIT = Number(process.env.PUBLIC_RATE_LIMIT || 60);
+const WINDOW = Number(process.env.PUBLIC_RATE_TTL || 60); // seconds
+
+export default async function rateLimit(redis, tenantId, ip) {
+  if (!ip) {
+    return true;
+  }
+  const key = `rate:${tenantId}:${ip}`;
+  const count = await redis.incr(key);
+  if (count === 1) {
+    await redis.expire(key, WINDOW);
+  }
+  return count <= LIMIT;
+}


### PR DESCRIPTION
## Summary
- add reusable rate limiter using Redis with TTL
- enforce per-IP and tenant request limits on `entrar`, `status`, and `chamar`

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b0e073ea108329814a14ea70e0efea