### PR TITLE
Add rate limiting to status function

### DIFF
--- a/functions/status.js
+++ b/functions/status.js
@@ -1,6 +1,11 @@
 import { Redis } from "@upstash/redis";
+import rateLimit from "./utils/rateLimiter.js";
 
 export async function handler(event) {
+  const ip = (event.headers && event.headers["x-forwarded-for"] || "").split(",")[0];
+  if (await rateLimit(ip)) {
+    return { statusCode: 429, body: "Too Many Requests" };
+  }
   const url      = new URL(event.rawUrl);
   const tenantId = url.searchParams.get("t");
   if (!tenantId) {

--- a/functions/utils/rateLimiter.js
+++ b/functions/utils/rateLimiter.js
@@ -1,0 +1,14 @@
+import { Redis } from "@upstash/redis";
+
+export default async function rateLimit(ip, limit = 60, windowSeconds = 60) {
+  if (!ip) {
+    return false;
+  }
+  const redis = Redis.fromEnv();
+  const key = `rl:${ip}`;
+  const count = await redis.incr(key);
+  if (count === 1) {
+    await redis.expire(key, windowSeconds);
+  }
+  return count > limit;
+}


### PR DESCRIPTION
## Summary
- add Redis-based rate limiter utility
- guard status function against excessive requests

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0f48622d48329be0fac107c30a675