### PR TITLE
feat: toggle password visibility on change modal

### DIFF
--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -640,12 +640,25 @@ body {
   font-size: 1.25rem;
   cursor: pointer;
 }
-#password-modal input {
+#password-modal .password-wrapper {
+  position: relative;
+  margin: 0.5rem 0;
+}
+#password-modal .password-wrapper input {
   width: 100%;
   padding: 0.5rem;
   border: 1px solid #ccc;
   border-radius: var(--radius);
-  margin: 0.5rem 0;
+  padding-right: 2.5rem;
+}
+#password-modal .toggle-password {
+  position: absolute;
+  top: 50%;
+  right: 0.5rem;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
 }
 #password-modal button {
   width: 100%;

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -245,8 +245,14 @@
     <div class="modal-content">
       <span id="password-close" class="close">&times;</span>
       <h2>Trocar Senha</h2>
-      <input id="password-current" type="password" placeholder="Senha Atual" />
-      <input id="password-new" type="password" placeholder="Nova Senha" />
+      <div class="password-wrapper">
+        <input id="password-current" type="password" placeholder="Senha Atual" />
+        <button type="button" id="toggle-password-current" class="toggle-password">👁️</button>
+      </div>
+      <div class="password-wrapper">
+        <input id="password-new" type="password" placeholder="Nova Senha" />
+        <button type="button" id="toggle-password-new" class="toggle-password">👁️</button>
+      </div>
       <button id="password-save">Salvar</button>
       <div id="password-error" class="error"></div>
     </div>

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -191,6 +191,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const passwordCurrent= document.getElementById('password-current');
   const passwordNew    = document.getElementById('password-new');
   const passwordError  = document.getElementById('password-error');
+  const togglePwCurrent= document.getElementById('toggle-password-current');
+  const togglePwNew    = document.getElementById('toggle-password-new');
   const cloneListEl    = document.getElementById('clone-list');
   const clonesPanel    = document.querySelector('.clones-panel');
 
@@ -280,8 +282,22 @@ document.addEventListener('DOMContentLoaded', () => {
   btnChangePw.onclick = () => {
     passwordError.textContent = '';
     passwordCurrent.value = '';
+    passwordCurrent.type = 'password';
+    togglePwCurrent.textContent = '👁️';
     passwordNew.value = '';
+    passwordNew.type = 'password';
+    togglePwNew.textContent = '👁️';
     passwordModal.hidden = false;
+  };
+  togglePwCurrent.onclick = () => {
+    const isPassword = passwordCurrent.type === 'password';
+    passwordCurrent.type = isPassword ? 'text' : 'password';
+    togglePwCurrent.textContent = isPassword ? '🙈' : '👁️';
+  };
+  togglePwNew.onclick = () => {
+    const isPassword = passwordNew.type === 'password';
+    passwordNew.type = isPassword ? 'text' : 'password';
+    togglePwNew.textContent = isPassword ? '🙈' : '👁️';
   };
   passwordClose.onclick = () => { passwordModal.hidden = true; };
   passwordSave.onclick = async () => {


### PR DESCRIPTION
## Summary
- hide and show current/new password via eye icons
- style password fields with inline toggle button
- reset password fields when opening modal

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b0f7cc1eb88329b5384d15dfc6c5c4