### PR TITLE
Use Redis hashes to fetch state in single calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ Funções serverless e front-end para a fila virtual SuaVez.
 A função `deleteMonitorConfig` apaga o registro do monitor e **todas** as chaves `tenant:{token}:*` associadas no Redis.
 Esse reset remove contadores, senha, label, tickets e logs, utilizando `SCAN`/`DEL` para eliminar também conjuntos e hashes da fila.
 
-Após o reset, todos os links do monitor e do cliente ficam inválidos e nenhum dado da fila é preservado.
+Após o reset, todos os links do monitor e do cliente ficam inválidos e nenhum dado da fila é preservado...

--- a/functions/chamar.js
+++ b/functions/chamar.js
@@ -19,12 +19,17 @@ export async function handler(event) {
     if (!pwHash && !monitor) {
       return { statusCode: 404, body: "Invalid link" };
     }
-    const prefix    = `tenant:${tenantId}:`;
-    const paramNum  = url.searchParams.get("num");
+    const prefix     = `tenant:${tenantId}:`;
+    const paramNum   = url.searchParams.get("num");
     const identifier = url.searchParams.get("id") || "";
 
-    const counterKey = prefix + "callCounter";
-    const prevCounter = Number(await redis.get(counterKey) || 0);
+    const stateKey = prefix + "state";
+    const [prevCounterRaw, ticketCountRaw] = await redis.hmget(
+      stateKey,
+      ["callCounter", "ticketCounter"]
+    );
+    let prevCounter = Number(prevCounterRaw || 0);
+    let ticketCount = Number(ticketCountRaw || 0);
 
     // Próximo a chamar
     let next;
@@ -36,8 +41,8 @@ export async function handler(event) {
       await redis.srem(prefix + "missedSet", String(next));
       await redis.srem(prefix + "skippedSet", String(next));
     } else {
-      next = await redis.incr(counterKey);
-      const ticketCount = Number(await redis.get(prefix + "ticketCounter") || 0);
+      next = await redis.hincrby(stateKey, "callCounter", 1);
+      ticketCount = Number(ticketCountRaw || 0);
       // Se automático, pular tickets cancelados, perdidos ou pulados sem removê-los
       while (
         next <= ticketCount &&
@@ -45,7 +50,7 @@ export async function handler(event) {
          (await redis.sismember(prefix + "missedSet", String(next))) ||
          (await redis.sismember(prefix + "skippedSet", String(next))))
       ) {
-        next = await redis.incr(counterKey);
+        next = await redis.hincrby(stateKey, "callCounter", 1);
       }
     }
 
@@ -90,15 +95,17 @@ export async function handler(event) {
     // Atualiza dados da chamada em um único comando
     const updateData = {
       [prefix + `wait:${next}`]: wait,
-      [prefix + "currentCall"]: next,
-      [prefix + "currentCallTs"]: ts,
       [prefix + `calledTime:${next}`]: ts,
+      ...(identifier ? { [prefix + `identifier:${next}`]: identifier } : {}),
     };
-    if (identifier) {
-      updateData[prefix + `identifier:${next}`] = identifier;
-      updateData[prefix + "currentAttendant"] = identifier;
-    }
-    await redis.mset(updateData);
+    await Promise.all([
+      redis.mset(updateData),
+      redis.hset(stateKey, {
+        currentCall: next,
+        currentCallTs: ts,
+        ...(identifier ? { currentAttendant: identifier } : {}),
+      }),
+    ]);
 
     const name = await redis.hget(prefix + "ticketNames", String(next));
 

--- a/functions/entrar.js
+++ b/functions/entrar.js
@@ -21,7 +21,8 @@ export async function handler(event) {
     if (!pwHash && !monitor) {
       return { statusCode: 404, body: "Invalid link" };
     }
-    const prefix = `tenant:${tenantId}:`;
+    const prefix   = `tenant:${tenantId}:`;
+    const stateKey = prefix + "state";
 
     let schedule = null;
     if (schedRaw) {
@@ -53,7 +54,7 @@ export async function handler(event) {
 
     // Cria clientId e incrementa contador de tickets
     const clientId     = uuidv4();
-    const ticketNumber = await redis.incr(prefix + "ticketCounter");
+    const ticketNumber = await redis.hincrby(stateKey, "ticketCounter", 1);
     // registra ticket e horário de entrada em um único comando
     await redis.mset({
       [prefix + `ticket:${clientId}`]: ticketNumber,

--- a/functions/manualTicket.js
+++ b/functions/manualTicket.js
@@ -19,9 +19,10 @@ export async function handler(event) {
   }
   const { name = "" } = JSON.parse(event.body || "{}");
 
-  const prefix = `tenant:${tenantId}:`;
+  const prefix   = `tenant:${tenantId}:`;
+  const stateKey = prefix + "state";
 
-  const ticketNumber = await redis.incr(prefix + "ticketCounter");
+  const ticketNumber = await redis.hincrby(stateKey, "ticketCounter", 1);
   await redis.set(prefix + `ticketTime:${ticketNumber}`, Date.now());
   if (name) {
     await redis.hset(prefix + "ticketNames", { [ticketNumber]: name });

--- a/functions/registerMonitor.js
+++ b/functions/registerMonitor.js
@@ -18,12 +18,15 @@ export async function handler(event) {
     await redis.set(`tenant:${tenantId}:label`, label);
     await redis.set(`tenant:${tenantId}:pwHash`, hash);
 
-    // Inicializa todos os contadores do tenant
-    await redis.set(`tenant:${tenantId}:ticketCounter`, 0);
-    await redis.set(`tenant:${tenantId}:callCounter`,  0);
-    await redis.set(`tenant:${tenantId}:currentCall`,  0);
-    await redis.set(`tenant:${tenantId}:currentCallTs`, Date.now());
-    await redis.set(`tenant:${tenantId}:logoutVersion`, 0);
+    // Inicializa todos os contadores do tenant em um único hash
+    const stateKey = `tenant:${tenantId}:state`;
+    await redis.hset(stateKey, {
+      ticketCounter: 0,
+      callCounter: 0,
+      currentCall: 0,
+      currentCallTs: Date.now(),
+      logoutVersion: 0,
+    });
     await redis.del(`tenant:${tenantId}:clones`);
 
     return {

--- a/functions/reset.js
+++ b/functions/reset.js
@@ -24,12 +24,15 @@ export async function handler(event) {
     const prefix = `tenant:${tenantId}:`;
     const ts     = Date.now();
 
-    // Zera todos os contadores
-    await redis.set(prefix + "ticketCounter", 0);
-    await redis.set(prefix + "callCounter",  0);
-    await redis.set(prefix + "currentCall",  0);
-    await redis.set(prefix + "currentCallTs", ts);
-    await redis.del(prefix + "currentAttendant");
+    // Zera todos os contadores em um único hash
+    const stateKey = prefix + "state";
+    await redis.hset(stateKey, {
+      ticketCounter: 0,
+      callCounter: 0,
+      currentCall: 0,
+      currentCallTs: ts,
+    });
+    await redis.hdel(stateKey, "currentAttendant");
     await redis.del(prefix + "cancelledSet");
     await redis.del(prefix + "missedSet");
     await redis.del(prefix + "attendedSet");


### PR DESCRIPTION
## Summary
- Store tenant state in a single Redis hash
- Replace multiple GET/SET commands with HMGET/HGETALL/HSET/HINCRBY
- Fix HMGET field usage so counters load correctly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2f85b92848329abb9ec5dcc3bac2f