### PR TITLE
feat(auth): OTP-based signup and password reset with session cookies

### DIFF
--- a/functions/attendant.js
+++ b/functions/attendant.js
@@ -1,0 +1,16 @@
+import { Redis } from '@upstash/redis';
+import { getSession } from './utils/session.js';
+import errorHandler from './utils/errorHandler.js';
+
+export async function handler(event) {
+  try {
+    const redis = Redis.fromEnv();
+    const sess = await getSession(redis, event.headers.cookie || '');
+    if (!sess) {
+      return { statusCode: 401, body: 'Unauthorized' };
+    }
+    return { statusCode: 200, body: JSON.stringify({ email: sess.email }) };
+  } catch (error) {
+    return errorHandler(error);
+  }
+}

--- a/functions/forgot.js
+++ b/functions/forgot.js
@@ -1,0 +1,42 @@
+import { Redis } from '@upstash/redis';
+import { sendOtpEmail } from './utils/sendEmail.js';
+import { rateLimit } from './utils/rateLimit.js';
+import errorHandler from './utils/errorHandler.js';
+
+function generateOtp() {
+  return Math.floor(100000 + Math.random() * 900000).toString();
+}
+
+export async function handler(event) {
+  try {
+    if (event.httpMethod !== 'POST') {
+      return { statusCode: 405, body: 'Method not allowed' };
+    }
+    const { email } = JSON.parse(event.body || '{}');
+    if (!email) {
+      return { statusCode: 400, body: 'Missing email' };
+    }
+    const normalized = email.trim().toLowerCase();
+    const redis = Redis.fromEnv();
+    const rlKey = `rl:forgot:${normalized}`;
+    if (await rateLimit(redis, rlKey, 5, 60)) {
+      return { statusCode: 429, body: 'Too many requests' };
+    }
+    const user = await redis.hgetall(`user:${normalized}`);
+    if (!user || user.email_verified !== 'true') {
+      return { statusCode: 200, body: JSON.stringify({ sent: true }) };
+    }
+    const cooldownKey = `otp:reset:${normalized}:cooldown`;
+    if (await redis.exists(cooldownKey)) {
+      return { statusCode: 429, body: 'Aguarde para reenviar' };
+    }
+    const otp = generateOtp();
+    await redis.set(`otp:reset:${normalized}`, otp, { ex: 60 * 15 });
+    await redis.set(`otp:reset:${normalized}:attempts`, 0, { ex: 60 * 15 });
+    await redis.set(cooldownKey, 1, { ex: 60 });
+    await sendOtpEmail(normalized, otp, 'Código para reset de senha');
+    return { statusCode: 200, body: JSON.stringify({ sent: true }) };
+  } catch (error) {
+    return errorHandler(error);
+  }
+}

--- a/functions/login.js
+++ b/functions/login.js
@@ -1,0 +1,41 @@
+import { Redis } from '@upstash/redis';
+import bcrypt from 'bcryptjs';
+import { createSession } from './utils/session.js';
+import { rateLimit } from './utils/rateLimit.js';
+import errorHandler from './utils/errorHandler.js';
+
+export async function handler(event) {
+  try {
+    if (event.httpMethod !== 'POST') {
+      return { statusCode: 405, body: 'Method not allowed' };
+    }
+    const { email, password } = JSON.parse(event.body || '{}');
+    if (!email || !password) {
+      return { statusCode: 400, body: 'Invalid request' };
+    }
+    const normalized = email.trim().toLowerCase();
+    const redis = Redis.fromEnv();
+    const rlKey = `rl:login:${normalized}`;
+    if (await rateLimit(redis, rlKey, 10, 60)) {
+      return { statusCode: 429, body: 'Too many requests' };
+    }
+    const user = await redis.hgetall(`user:${normalized}`);
+    if (!user || user.email_verified !== 'true' || !user.password_hash) {
+      return { statusCode: 400, body: 'Credenciais inválidas' };
+    }
+    const valid = await bcrypt.compare(password, user.password_hash);
+    if (!valid) {
+      return { statusCode: 400, body: 'Credenciais inválidas' };
+    }
+    const sid = await createSession(redis, normalized);
+    return {
+      statusCode: 200,
+      headers: {
+        'Set-Cookie': `session=${sid}; HttpOnly; Secure; Path=/; SameSite=Lax`,
+      },
+      body: JSON.stringify({ ok: true }),
+    };
+  } catch (error) {
+    return errorHandler(error);
+  }
+}

--- a/functions/logout.js
+++ b/functions/logout.js
@@ -1,0 +1,22 @@
+import { Redis } from '@upstash/redis';
+import { getSession, destroySession } from './utils/session.js';
+import errorHandler from './utils/errorHandler.js';
+
+export async function handler(event) {
+  try {
+    const redis = Redis.fromEnv();
+    const sess = await getSession(redis, event.headers.cookie || '');
+    if (sess) {
+      await destroySession(redis, sess.sid);
+    }
+    return {
+      statusCode: 200,
+      headers: {
+        'Set-Cookie': 'session=; Max-Age=0; HttpOnly; Secure; Path=/; SameSite=Lax',
+      },
+      body: JSON.stringify({ ok: true }),
+    };
+  } catch (error) {
+    return errorHandler(error);
+  }
+}

--- a/functions/reset.js
+++ b/functions/reset.js
@@ -1,64 +1,114 @@
 import { Redis } from "@upstash/redis";
 import scanDelete from "./utils/scanDelete.js";
 import errorHandler from "./utils/errorHandler.js";
+import bcrypt from 'bcryptjs';
+import { createSession } from './utils/session.js';
 
 const LOG_TTL = 60 * 60 * 24 * 30; // 30 days
 
+async function handleQueueReset(event, redis) {
+  const url        = new URL(event.rawUrl);
+  const tenantId   = url.searchParams.get("t");
+  const attendant  = url.searchParams.get("id") || "";
+  if (!tenantId) {
+    return { statusCode: 400, body: "Missing tenantId" };
+  }
+
+  const [pwHash, monitor] = await redis.mget(
+    `tenant:${tenantId}:pwHash`,
+    `monitor:${tenantId}`
+  );
+  if (!pwHash && !monitor) {
+    return { statusCode: 404, body: "Invalid link" };
+  }
+  const prefix = `tenant:${tenantId}:`;
+  const ts     = Date.now();
+
+  // Zera todos os contadores
+  await redis.set(prefix + "ticketCounter", 0);
+  await redis.set(prefix + "callCounter",  0);
+  await redis.set(prefix + "currentCall",  0);
+  await redis.set(prefix + "currentCallTs", ts);
+  await redis.del(prefix + "currentAttendant");
+  await redis.del(prefix + "cancelledSet");
+  await redis.del(prefix + "missedSet");
+  await redis.del(prefix + "attendedSet");
+  await redis.del(prefix + "skippedSet");
+  await redis.del(prefix + "offHoursSet");
+  await redis.del(prefix + "ticketNames");
+  await redis.del(prefix + "log:entered");
+  await redis.del(prefix + "log:called");
+  await redis.del(prefix + "log:attended");
+  await redis.del(prefix + "log:cancelled");
+  await redis.del(prefix + "log:reset");
+  await scanDelete(redis, prefix + "ticketTime:*");
+  await scanDelete(redis, prefix + "calledTime:*");
+  await scanDelete(redis, prefix + "attendedTime:*");
+  await scanDelete(redis, prefix + "cancelledTime:*");
+  await scanDelete(redis, prefix + "wait:*");
+
+  // Log de reset
+  await redis.lpush(
+    prefix + "log:reset",
+    JSON.stringify({ attendant, ts })
+  );
+  await redis.ltrim(prefix + "log:reset", 0, 999);
+  await redis.expire(prefix + "log:reset", LOG_TTL);
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({ reset: true, attendant, ts }),
+  };
+}
+
+async function handlePasswordReset(body, redis) {
+  const { email, otp, password } = body;
+  const normalized = email.trim().toLowerCase();
+  const otpKey = `otp:reset:${normalized}`;
+  const attemptsKey = `otp:reset:${normalized}:attempts`;
+  const stored = await redis.get(otpKey);
+  if (!stored) {
+    return { statusCode: 400, body: 'OTP inválido' };
+  }
+  const attempts = await redis.incr(attemptsKey);
+  if (attempts > 5) {
+    await redis.del(otpKey);
+    await redis.del(attemptsKey);
+    return { statusCode: 400, body: 'OTP expirado' };
+  }
+  if (stored !== otp) {
+    return { statusCode: 400, body: 'OTP inválido' };
+  }
+  const userKey = `user:${normalized}`;
+  const user = await redis.hgetall(userKey);
+  if (!user || user.email_verified !== 'true') {
+    return { statusCode: 400, body: 'Usuário inválido' };
+  }
+  const hash = await bcrypt.hash(password, 10);
+  await redis.hset(userKey, { password_hash: hash });
+  await redis.del(otpKey);
+  await redis.del(attemptsKey);
+  const sid = await createSession(redis, normalized);
+  return {
+    statusCode: 200,
+    headers: {
+      'Set-Cookie': `session=${sid}; HttpOnly; Secure; Path=/; SameSite=Lax`,
+    },
+    body: JSON.stringify({ ok: true }),
+  };
+}
+
 export async function handler(event) {
   try {
-    const url        = new URL(event.rawUrl);
-    const tenantId   = url.searchParams.get("t");
-    const attendant  = url.searchParams.get("id") || "";
-    if (!tenantId) {
-      return { statusCode: 400, body: "Missing tenantId" };
+    const redis = Redis.fromEnv();
+    let body = {};
+    if (event.body) {
+      try { body = JSON.parse(event.body); } catch {}
     }
-
-    const redis  = Redis.fromEnv();
-    const [pwHash, monitor] = await redis.mget(
-      `tenant:${tenantId}:pwHash`,
-      `monitor:${tenantId}`
-    );
-    if (!pwHash && !monitor) {
-      return { statusCode: 404, body: "Invalid link" };
+    if (body.email && body.otp && body.password) {
+      return await handlePasswordReset(body, redis);
     }
-    const prefix = `tenant:${tenantId}:`;
-    const ts     = Date.now();
-
-    // Zera todos os contadores
-    await redis.set(prefix + "ticketCounter", 0);
-    await redis.set(prefix + "callCounter",  0);
-    await redis.set(prefix + "currentCall",  0);
-    await redis.set(prefix + "currentCallTs", ts);
-    await redis.del(prefix + "currentAttendant");
-    await redis.del(prefix + "cancelledSet");
-    await redis.del(prefix + "missedSet");
-    await redis.del(prefix + "attendedSet");
-    await redis.del(prefix + "skippedSet");
-    await redis.del(prefix + "offHoursSet");
-    await redis.del(prefix + "ticketNames");
-    await redis.del(prefix + "log:entered");
-    await redis.del(prefix + "log:called");
-    await redis.del(prefix + "log:attended");
-    await redis.del(prefix + "log:cancelled");
-    await redis.del(prefix + "log:reset");
-    await scanDelete(redis, prefix + "ticketTime:*");
-    await scanDelete(redis, prefix + "calledTime:*");
-    await scanDelete(redis, prefix + "attendedTime:*");
-    await scanDelete(redis, prefix + "cancelledTime:*");
-    await scanDelete(redis, prefix + "wait:*");
-
-    // Log de reset
-    await redis.lpush(
-      prefix + "log:reset",
-      JSON.stringify({ attendant, ts })
-    );
-    await redis.ltrim(prefix + "log:reset", 0, 999);
-    await redis.expire(prefix + "log:reset", LOG_TTL);
-
-    return {
-      statusCode: 200,
-      body: JSON.stringify({ reset: true, attendant, ts }),
-    };
+    return await handleQueueReset(event, redis);
   } catch (error) {
     return errorHandler(error);
   }

--- a/functions/set-password.js
+++ b/functions/set-password.js
@@ -1,0 +1,41 @@
+import { Redis } from '@upstash/redis';
+import bcrypt from 'bcryptjs';
+import { createSession } from './utils/session.js';
+import { rateLimit } from './utils/rateLimit.js';
+import errorHandler from './utils/errorHandler.js';
+
+export async function handler(event) {
+  try {
+    if (event.httpMethod !== 'POST') {
+      return { statusCode: 405, body: 'Method not allowed' };
+    }
+    const { email, password } = JSON.parse(event.body || '{}');
+    if (!email || !password) {
+      return { statusCode: 400, body: 'Invalid request' };
+    }
+    const normalized = email.trim().toLowerCase();
+    const redis = Redis.fromEnv();
+    const rlKey = `rl:setpw:${normalized}`;
+    if (await rateLimit(redis, rlKey, 10, 60)) {
+      return { statusCode: 429, body: 'Too many requests' };
+    }
+    const userKey = `user:${normalized}`;
+    const user = await redis.hgetall(userKey);
+    if (!user || user.email_verified !== 'true') {
+      return { statusCode: 400, body: 'Usuário não verificado' };
+    }
+    const hash = await bcrypt.hash(password, 10);
+    await redis.hset(userKey, { password_hash: hash });
+
+    const sid = await createSession(redis, normalized);
+    return {
+      statusCode: 200,
+      headers: {
+        'Set-Cookie': `session=${sid}; HttpOnly; Secure; Path=/; SameSite=Lax`,
+      },
+      body: JSON.stringify({ ok: true }),
+    };
+  } catch (error) {
+    return errorHandler(error);
+  }
+}

--- a/functions/signup-start.js
+++ b/functions/signup-start.js
@@ -1,0 +1,49 @@
+import { Redis } from '@upstash/redis';
+import { sendOtpEmail } from './utils/sendEmail.js';
+import { rateLimit } from './utils/rateLimit.js';
+import errorHandler from './utils/errorHandler.js';
+
+function generateOtp() {
+  return Math.floor(100000 + Math.random() * 900000).toString();
+}
+
+export async function handler(event) {
+  try {
+    if (event.httpMethod !== 'POST') {
+      return { statusCode: 405, body: 'Method not allowed' };
+    }
+    const { email } = JSON.parse(event.body || '{}');
+    if (!email) {
+      return { statusCode: 400, body: 'Missing email' };
+    }
+    const normalized = email.trim().toLowerCase();
+    const redis = Redis.fromEnv();
+    const rlKey = `rl:signup:${normalized}`;
+    if (await rateLimit(redis, rlKey, 5, 60)) {
+      return { statusCode: 429, body: 'Too many requests' };
+    }
+
+    const cooldownKey = `otp:signup:${normalized}:cooldown`;
+    if (await redis.exists(cooldownKey)) {
+      return { statusCode: 429, body: 'Aguarde para reenviar' };
+    }
+    const userKey = `user:${normalized}`;
+    const user = await redis.hgetall(userKey);
+    if (!user || Object.keys(user).length === 0) {
+      await redis.hset(userKey, { email_verified: 'false' });
+    } else if (user.email_verified === 'true') {
+      return { statusCode: 400, body: 'Email já registrado' };
+    }
+
+    const otp = generateOtp();
+    await redis.set(`otp:signup:${normalized}`, otp, { ex: 60 * 15 });
+    await redis.set(`otp:signup:${normalized}:attempts`, 0, { ex: 60 * 15 });
+    await redis.set(cooldownKey, 1, { ex: 60 });
+
+    await sendOtpEmail(normalized, otp, 'Código de verificação');
+
+    return { statusCode: 200, body: JSON.stringify({ sent: true }) };
+  } catch (error) {
+    return errorHandler(error);
+  }
+}

--- a/functions/signup-verify.js
+++ b/functions/signup-verify.js
@@ -1,0 +1,43 @@
+import { Redis } from '@upstash/redis';
+import { rateLimit } from './utils/rateLimit.js';
+import errorHandler from './utils/errorHandler.js';
+
+export async function handler(event) {
+  try {
+    if (event.httpMethod !== 'POST') {
+      return { statusCode: 405, body: 'Method not allowed' };
+    }
+    const { email, otp } = JSON.parse(event.body || '{}');
+    if (!email || !otp) {
+      return { statusCode: 400, body: 'Invalid request' };
+    }
+    const normalized = email.trim().toLowerCase();
+    const redis = Redis.fromEnv();
+    const rlKey = `rl:signup-verify:${normalized}`;
+    if (await rateLimit(redis, rlKey, 10, 60)) {
+      return { statusCode: 429, body: 'Too many requests' };
+    }
+
+    const otpKey = `otp:signup:${normalized}`;
+    const attemptsKey = `otp:signup:${normalized}:attempts`;
+    const stored = await redis.get(otpKey);
+    if (!stored) {
+      return { statusCode: 400, body: 'OTP inválido' };
+    }
+    const attempts = await redis.incr(attemptsKey);
+    if (attempts > 5) {
+      await redis.del(otpKey);
+      await redis.del(attemptsKey);
+      return { statusCode: 400, body: 'OTP expirado' };
+    }
+    if (stored !== otp) {
+      return { statusCode: 400, body: 'OTP inválido' };
+    }
+    await redis.del(otpKey);
+    await redis.del(attemptsKey);
+    await redis.hset(`user:${normalized}`, { email_verified: 'true' });
+    return { statusCode: 200, body: JSON.stringify({ verified: true }) };
+  } catch (error) {
+    return errorHandler(error);
+  }
+}

--- a/functions/utils/rateLimit.js
+++ b/functions/utils/rateLimit.js
@@ -1,0 +1,7 @@
+export async function rateLimit(redis, key, limit = 5, ttl = 60) {
+  const count = await redis.incr(key);
+  if (count === 1) {
+    await redis.expire(key, ttl);
+  }
+  return count > limit;
+}

--- a/functions/utils/sendEmail.js
+++ b/functions/utils/sendEmail.js
@@ -1,0 +1,23 @@
+import nodemailer from 'nodemailer';
+
+export async function sendOtpEmail(to, code, subject) {
+  if (!process.env.SMTP_HOST) {
+    console.warn('SMTP not configured');
+    return;
+  }
+  const transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: Number(process.env.SMTP_PORT) || 587,
+    secure: false,
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS,
+    },
+  });
+  await transporter.sendMail({
+    from: process.env.FROM_EMAIL,
+    to,
+    subject,
+    text: `Seu código de verificação é ${code}`,
+  });
+}

--- a/functions/utils/session.js
+++ b/functions/utils/session.js
@@ -1,0 +1,20 @@
+import { v4 as uuidv4 } from 'uuid';
+
+export async function createSession(redis, email) {
+  const sid = uuidv4();
+  await redis.set(`session:${sid}`, email, { ex: 60 * 60 * 24 * 7 });
+  return sid;
+}
+
+export async function getSession(redis, cookies = '') {
+  const match = cookies.match(/session=([^;]+)/);
+  if (!match) return null;
+  const sid = match[1];
+  const email = await redis.get(`session:${sid}`);
+  if (!email) return null;
+  return { sid, email };
+}
+
+export async function destroySession(redis, sid) {
+  await redis.del(`session:${sid}`);
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "@upstash/redis": "^1.20.0",
     "uuid": "^9.0.0",
     "bcryptjs": "^2.4.3",
-    "faunadb": "^4.6.0"
+    "faunadb": "^4.6.0",
+    "nodemailer": "^6.9.8"
   },
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
## Summary
- implement signup with email OTP verification and session creation on set-password
- add login, logout, forgot-password and OTP reset flows; protect attendant route via cookie session
- update reset function to handle password resets and add mailer utilities

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@upstash%2fredis)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c8150484832980bb512913ce7d8f